### PR TITLE
feat(t3-toon): add TYPO3 v14-specific icon registration

### DIFF
--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -2,15 +2,22 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
+$isV14OrHigher = (new Typo3Version())->getMajorVersion() >= 14;
 
 return [
     'extension-rrp-t3toon' => [
         'provider' => SvgIconProvider::class,
-        'source' => 'EXT:rrp_t3toon/Resources/Public/Icons/Extension.svg',
+        'source' => $isV14OrHigher
+            ? 'EXT:rrp_t3toon/Resources/Public/Icons/ExtensionV14.svg'
+            : 'EXT:rrp_t3toon/Resources/Public/Icons/Extension.svg',
     ],
     'module-rrp-t3toon-logs' => [
         'provider' => SvgIconProvider::class,
-        'source' => 'EXT:rrp_t3toon/Resources/Public/Icons/ModuleLogs.svg',
+        'source' => $isV14OrHigher
+            ? 'EXT:rrp_t3toon/Resources/Public/Icons/ModuleLogsV14.svg'
+            : 'EXT:rrp_t3toon/Resources/Public/Icons/ModuleLogs.svg',
     ],
 ];

--- a/Resources/Public/Icons/ExtensionV14.svg
+++ b/Resources/Public/Icons/ExtensionV14.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="14" y="16" width="36" height="6" rx="3" fill="currentColor"/>
+  <rect x="29.5" y="24" width="5" height="9" rx="2" fill="currentColor" opacity="0.9"/>
+  <rect x="29.5" y="35" width="5" height="9" rx="2" fill="currentColor" opacity="0.75"/>
+  <rect x="29.5" y="46" width="5" height="6" rx="2" fill="currentColor" opacity="0.6"/>
+  <path d="M44 10l1.2 3.4L49 15l-3.8 1.6L44 20l-1.2-3.4L39 15l3.8-1.6L44 10z" fill="var(--icon-color-accent, #ff8700)"/>
+</svg>

--- a/Resources/Public/Icons/ModuleLogsV14.svg
+++ b/Resources/Public/Icons/ModuleLogsV14.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="14" y="16" width="36" height="5" rx="2.5" fill="currentColor"/>
+  <rect x="14" y="24" width="36" height="5" rx="2.5" fill="currentColor" opacity="0.85"/>
+  <rect x="14" y="32" width="36" height="5" rx="2.5" fill="currentColor" opacity="0.7"/>
+  <rect x="14" y="40" width="24" height="5" rx="2.5" fill="currentColor" opacity="0.55"/>
+  <circle cx="52" cy="12" r="4" fill="var(--icon-color-accent, #ff8700)"/>
+</svg>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "rrp/t3-toon",
-    "description": "TOON for TYPO3 — a compact, human-readable, and token-efficient data format for AI prompts & LLM contexts. Perfect for ChatGPT, Gemini, Claude, Mistral, and OpenAI integrations (JSON ⇄ TOON).",
+    "description": "TOON for TYPO3 — AI-ready data format for LLM prompts, AI agents, ChatGPT, Gemini, Claude, Mistral, OpenAI, and TYPO3 AI integrations. Convert JSON ⇄ TOON for compact, token-efficient AI context exchange.",
     "type": "typo3-cms-extension",
     "license": "MIT",
     "authors": [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,7 +2,7 @@
 
 $EM_CONF['rrp_t3toon'] = [
     'title' => 'T3Toon – Token-Efficient Data Format for TYPO3 AI',
-    'description' => 'TOON for TYPO3 — a compact, human-readable, and token-efficient data format for AI prompts & LLM contexts. Perfect for ChatGPT, Gemini, Claude, Mistral, and OpenAI integrations (JSON ⇄ TOON).',
+    'description' => 'TOON for TYPO3 — AI-ready data format for LLM prompts, AI agents, ChatGPT, Gemini, Claude, Mistral, OpenAI, and TYPO3 AI integrations. Convert JSON ⇄ TOON for compact, token-efficient AI context exchange.',
     'category' => 'be',
     'author' => 'Rohan Parmar | Himanshu Ramavat',
     'author_email' => 'rohanrparmar987@gmail.com | himanshuramavat07@gmail.com',


### PR DESCRIPTION
Add dedicated v14 icon assets for extension and logs module and switch icon sources conditionally by TYPO3 major version. Keep existing icon files for v13 and below to preserve backward compatibility.

Releted issue: #11 